### PR TITLE
Fix part of #21308: Add tests to cover branches of the backend code (core/controllers/story_editor_test.py)

### DIFF
--- a/core/controllers/story_editor_test.py
+++ b/core/controllers/story_editor_test.py
@@ -586,3 +586,58 @@ class StoryEditorTests(BaseStoryEditorControllerTests):
         self.assertEqual(url_fragment_exists, False)
 
         self.logout()
+
+    # Unsuccessful Attempt to cover branch 142->141
+    def test_story_id_matches_in_canonical_story_references(self):
+        # Create a topic object with a matching reference.
+        class MockStoryReference:
+            def __init__(self, story_id, story_is_published):
+                self.story_id = story_id
+                self.story_is_published = story_is_published
+
+        class MockTopic:
+            def __init__(self, references):
+                self.canonical_story_references = references
+
+        matching_story_id = self.story_id
+
+        mock_references = [
+            MockStoryReference(story_id=matching_story_id, story_is_published=True)
+        ]
+
+        mock_topic = MockTopic(mock_references)
+
+        # Simulate the branch where story_reference.story_id == story_id.
+        story_id_found = False
+        for story_reference in mock_topic.canonical_story_references:
+            if story_reference.story_id == self.story_id:
+                story_id_found = True
+
+        self.assertTrue(story_id_found)
+    
+    def test_story_id_does_not_match_in_canonical_story_references(self):
+        # Create a topic object with a mismatched reference.
+        class MockStoryReference:
+            def __init__(self, story_id, story_is_published):
+                self.story_id = story_id
+                self.story_is_published = story_is_published
+
+        class MockTopic:
+            def __init__(self, references):
+                self.canonical_story_references = references
+
+        mismatched_story_id = "mismatched_story_id"
+
+        mock_references = [
+            MockStoryReference(story_id=mismatched_story_id, story_is_published=False)
+        ]
+
+        mock_topic = MockTopic(mock_references)
+
+        # Simulate the branch where story_reference.story_id != story_id.
+        story_id_found = False
+        for story_reference in mock_topic.canonical_story_references:
+            if story_reference.story_id == self.story_id:
+                story_id_found = True
+
+        self.assertFalse(story_id_found)


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #21308.
2. This PR does the following: Added two test cases attempting to cover the 142->141 branch of the backend code in core/controllers/story_editor.py 
3. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->
I attempted to cover the branch 142 -> 141 in core/controllers/story_editor.py. I added two test cases covering both scenarios of the if statement, when the story id matches in canonical story references and when the story id doesn't match. While this attempt did not successfully cover the branch, I think it is a reasonable attempt and documented it to develop upon it.
 
<img width="1084" alt="Screenshot 2024-12-07 at 8 15 09 PM" src="https://github.com/user-attachments/assets/f44fcce2-e0e5-4a2f-bcd0-47c1f49a8d1d">

All test coverage reports are generated using the command: make run_tests.backend PYTHON_ARGS="--test_targets=core.controllers.story_editor_test --generate_coverage_report"

The added tests all passed, didn't break existing tests, and passed other checks like Prettier and Linter. ChatGPT assisted in the writing of the two test cases.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
