### PR TITLE
Fix part of #21308: Add tests to cover branches of the backend code (core/controllers/topics_and_skills_dashboard_test.py)

### DIFF
--- a/core/controllers/topics_and_skills_dashboard_test.py
+++ b/core/controllers/topics_and_skills_dashboard_test.py
@@ -35,6 +35,7 @@ from core.tests import test_utils
 
 from typing import Callable, Dict, List
 
+from unittest.mock import patch
 
 class BaseTopicsAndSkillsDashboardTests(test_utils.GenericTestBase):
 
@@ -171,6 +172,27 @@ class TopicsAndSkillsDashboardPageDataHandlerTests(
         self.assertIn(
             b'{"title": "Topics and Skills Dashboard - Oppia"})', response.body)
 
+        self.logout()
+
+    # Tests for Empty States or Unauthorized Access
+    def test_dashboard_with_no_data(self):
+        with patch('core.domain.topic_fetchers.get_all_topic_summaries', return_value=[]), \
+             patch('core.domain.skill_services.get_all_skill_summaries', return_value=[]):
+            self.login(self.CURRICULUM_ADMIN_EMAIL)
+            json_response = self.get_json(feconf.TOPICS_AND_SKILLS_DASHBOARD_DATA_URL)
+
+            # Assert that there are no topics or skills in the response.
+            self.assertEqual(len(json_response['topic_summary_dicts']), 0)
+            self.assertEqual(len(json_response['untriaged_skill_summary_dicts']), 0)
+
+            self.logout()
+
+    def test_unauthorized_access_to_dashboard(self):
+        self.login(self.NEW_USER_EMAIL)
+        self.get_json(
+            feconf.TOPICS_AND_SKILLS_DASHBOARD_DATA_URL,
+            expected_status_int=401
+        )
         self.logout()
 
 


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #21308.
2. This PR does the following: Added two test cases under class TopicsAndSkillsDashboardPageDataHandlerTests, attempting to cover branches 57, 73-175, 191-214, 243-249, 325-340, 450-494, 580-625, 675-699, 716-718, 753-761 of the backend code in core/controllers/topics_and_skills_dashboard.py
3. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [ ] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [x] I have written tests for my code.
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).


## Proof that changes are correct

<!--
Add before-and-after videos/screenshots of the user-facing interface (including
the browser devtools console) to demonstrate that the changes made in this PR
work correctly. Make sure the actions taken in the before and after videos are
the same. (For changes involving responsiveness or adjustment of UI elements,
this should be a video that gradually resizes the viewport from wide to narrow
and back again.) If this PR is for a developer-facing feature, provide
videos/screenshots of the developer-facing interface instead.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

Before the tests were added, the coverage report for this file was:
<img width="1234" alt="Screenshot 2024-12-07 at 9 20 35 PM" src="https://github.com/user-attachments/assets/821c7ce7-cd1a-4fa3-8d47-9e1f398a149d">

After added the test cases, the coverage report for this file became:
<img width="1233" alt="Screenshot 2024-12-07 at 10 17 17 PM" src="https://github.com/user-attachments/assets/8c36f03d-66ec-434c-8dbd-4407bb59e6ca">

The added two test cases under class TopicsAndSkillsDashboardPageDataHandlerTests cover the edge cases of empty states and unauthorized access, successfully increased coverage on this file from 37% to 99%. Currently the branches uncovered are 91->90, 93->90, 589->597. While I made several attempts to cover these three branches, including edge cases of no topic_rights_dict entry for a topic_summary, when topic_rights is None, and when skill was created without linked_topic_ids. However, the tests on these edge cases kept failing. I will look for new ways to cover the branches and better ways to write tests.

All test coverage reports are generated using the command: make run_tests.backend PYTHON_ARGS="--test_targets=core.controllers.topics_and_skills_dashboard_test --generate_coverage_report"

The added tests all passed, didn't break existing tests, and passed other checks like Prettier and Linter. ChatGPT assisted in the writing of the two test cases.


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
